### PR TITLE
Allow the auth source to be overridden - required for MongoDB Atlas

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -20,6 +20,7 @@ FORUM_MONGO_TAGS: !!null
 FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
 FORUM_MONGO_USE_SSL: false
+FORUM_MONGO_AUTH_SOURCE: {{ FORUM_MONGO_DATABASE }}
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
 FORUM_RACK_ENV: "development"
@@ -59,6 +60,7 @@ forum_base_env: &forum_base_env
   SEARCH_SERVER: "{{ FORUM_ELASTICSEARCH_URL }}"
   MONGOHQ_URL: "{{ FORUM_MONGO_URL }}"
   MONGOID_USE_SSL: "{{ FORUM_MONGO_USE_SSL }}"
+  MONGOID_AUTH_SOURCE: "{{ FORUM_MONGO_AUTH_SOURCE }}"
   HOME: "{{ forum_app_dir }}"
   NEW_RELIC_ENABLE: "{{ FORUM_NEW_RELIC_ENABLE }}"
   NEW_RELIC_APP_NAME: "{{ FORUM_NEW_RELIC_APP_NAME }}"

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -20,7 +20,7 @@ FORUM_MONGO_TAGS: !!null
 FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
 FORUM_MONGO_USE_SSL: false
-FORUM_MONGO_AUTH_SOURCE: {{ FORUM_MONGO_DATABASE }}
+FORUM_MONGO_AUTH_SOURCE: "{{ FORUM_MONGO_DATABASE }}"
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
 FORUM_RACK_ENV: "development"


### PR DESCRIPTION
## Summary 
MongoDB Atlas uses 'admin' DB for authentication. This defaults the auth source DB to be the same as the forum DB. This may be a breaking non backwards compatible change depending on the MongoDB config. 

See https://docs.atlas.mongodb.com/security-add-mongodb-users/\#enter-user-information 'User Name' for  details
